### PR TITLE
Discord authorizes with email, not with username.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ In order to execute the application, simply run the executable, which lies at
 On launch, cordless will offer you two login methods:
 
 1. Using an authentication token
-2. Using username and password
+2. Using email and password
 
 I recommend the first way, as the second one won't work anyway in case you have
 two-factor authentication enabled. After logging on using either method, your

--- a/internal/app.go
+++ b/internal/app.go
@@ -110,7 +110,7 @@ func Run() {
 }
 
 func login() (*discordgo.Session, error) {
-	log.Println("Please choose wether to login via username and password (1) or authentication token (2).")
+	log.Println("Please choose wether to login via email and password (1) or authentication token (2).")
 	var choice int
 
 	_, err := fmt.Scanf("%d\n", &choice)
@@ -136,13 +136,13 @@ func askForUsernameAndPassword() (*discordgo.Session, error) {
 
 	nameAsBytes, _, inputError := reader.ReadLine()
 	if inputError != nil {
-		log.Fatalf("Error reading your username (%s).\n", inputError.Error())
+		log.Fatalf("Error reading your email (%s).\n", inputError.Error())
 	}
 	name := string(nameAsBytes[:])
 
 	passwordAsBytes, inputError := getpass.Get("Please input your password.\n")
 	if inputError != nil {
-		log.Fatalf("Error reading your username (%s).\n", inputError.Error())
+		log.Fatalf("Error reading your email (%s).\n", inputError.Error())
 	}
 	password := string(passwordAsBytes[:])
 

--- a/internal/app.go
+++ b/internal/app.go
@@ -110,7 +110,7 @@ func Run() {
 }
 
 func login() (*discordgo.Session, error) {
-	log.Println("Please choose wether to login via email and password (1) or authentication token (2).")
+	log.Println("Please choose wether to login via authentication token (1) or email and password (2).")
 	var choice int
 
 	_, err := fmt.Scanf("%d\n", &choice)
@@ -121,16 +121,16 @@ func login() (*discordgo.Session, error) {
 	}
 
 	if choice == 1 {
-		return askForUsernameAndPassword()
-	} else if choice == 2 {
 		return askForToken()
+	} else if choice == 2 {
+		return askForEmailAndPassword()
 	} else {
 		log.Println("Invalid choice, please try again.")
 		return login()
 	}
 }
 
-func askForUsernameAndPassword() (*discordgo.Session, error) {
+func askForEmailAndPassword() (*discordgo.Session, error) {
 	log.Println("Please input your username.")
 	reader := bufio.NewReader(os.Stdin)
 


### PR DESCRIPTION
I was surprised why I couldn't log in with my username, I tried it with `username#tag` and then read this line `HTTP 400 Bad Request, {"email": ["Not a well formed email address."]}`. So by merging that pr, users won't get confused why cordless asks them for username and not email.