### PR TITLE
Newline codeblock

### DIFF
--- a/shortcuts/shortcuts.go
+++ b/shortcuts/shortcuts.go
@@ -68,6 +68,9 @@ var (
 	SendMessage = addShortcut("send_message", "Sends the typed message",
 		multilineTextInput, tcell.NewEventKey(tcell.KeyEnter, rune(tcell.KeyEnter), tcell.ModNone))
 
+	AddNewLineInCodeBlock = addShortcut("add_new_line_in_code_block", "Adds a new line inside a code block",
+		multilineTextInput, tcell.NewEventKey(tcell.KeyEnter, rune(tcell.KeyEnter), tcell.ModNone))
+
 	ExitApplication = addShortcut("exit_application", "Exit application",
 		globalScope, tcell.NewEventKey(tcell.KeyCtrlC, rune(tcell.KeyCtrlC), tcell.ModCtrl))
 

--- a/ui/window.go
+++ b/ui/window.go
@@ -843,15 +843,10 @@ func NewWindow(doRestart chan bool, app *tview.Application, session *discordgo.S
 }
 
 func (window *Window) insertNewLineAtCursor(messageToSend string) {
-	// Insert new line char
 	left := window.messageInput.internalTextView.GetRegionText("left")
 	right := window.messageInput.internalTextView.GetRegionText("right")
 	selection := window.messageInput.internalTextView.GetRegionText("selection")
-	if len(selection) == 1 {
-		window.messageInput.InsertCharacter([]rune(left), []rune(right), []rune(selection), '\n')
-	} else {
-		window.messageInput.SetText(left + "\n" + right)
-	}
+	window.messageInput.InsertCharacter([]rune(left), []rune(right), []rune(selection), '\n')
 	window.app.QueueUpdateDraw(func() {
 		window.messageInput.triggerHeightRequestIfNeccessary()
 		window.messageInput.internalTextView.ScrollToHighlight()

--- a/ui/window.go
+++ b/ui/window.go
@@ -430,13 +430,16 @@ func NewWindow(doRestart chan bool, app *tview.Application, session *discordgo.S
 			return nil
 		}
 
-		if window.selectedChannel != nil {
-			if shortcuts.AddNewLineInCodeBlock.Equals(event) && window.IsCursorInsideCodeBlock() {
-				window.insertNewLineAtCursor(messageToSend)
-			} else if shortcuts.SendMessage.Equals(event) {
+		if shortcuts.AddNewLineInCodeBlock.Equals(event) && window.IsCursorInsideCodeBlock() {
+			window.insertNewLineAtCursor(messageToSend)
+			return nil
+		} else if shortcuts.SendMessage.Equals(event) {
+			if window.selectedChannel != nil {
 				window.TrySendMessage(window.selectedChannel, messageToSend)
 			}
+			return nil
 		}
+
 		return event
 	})
 

--- a/ui/window.go
+++ b/ui/window.go
@@ -432,7 +432,15 @@ func NewWindow(doRestart chan bool, app *tview.Application, session *discordgo.S
 
 		if event.Key() == tcell.KeyEnter {
 			if window.selectedChannel != nil {
-				window.TrySendMessage(window.selectedChannel, messageToSend)
+				left := []rune(window.messageInput.internalTextView.GetRegionText("left"))
+				right := []rune(window.messageInput.internalTextView.GetRegionText("right"))
+				if window.IsCursorInsideCodeBlock(left, right) {
+					// Insert new line char
+					selection := []rune(window.messageInput.internalTextView.GetRegionText("selection"))
+					window.messageInput.InsertCharacter(left, right, selection, '\n')
+				} else {
+					window.TrySendMessage(window.selectedChannel, messageToSend)
+				}
 			}
 		}
 
@@ -839,6 +847,11 @@ func NewWindow(doRestart chan bool, app *tview.Application, session *discordgo.S
 	window.registerMouseFocusListeners()
 
 	return window, nil
+}
+
+func (window *Window) IsCursorInsideCodeBlock(left, right []rune) bool {
+	// TODO: Implement based on existing client's functionality.
+	return false
 }
 
 func (window *Window) insertQuoteOfMessage(message *discordgo.Message) {

--- a/ui/window.go
+++ b/ui/window.go
@@ -844,10 +844,14 @@ func NewWindow(doRestart chan bool, app *tview.Application, session *discordgo.S
 
 func (window *Window) insertNewLineAtCursor(messageToSend string) {
 	// Insert new line char
-	left := []rune(window.messageInput.internalTextView.GetRegionText("left"))
-	right := []rune(window.messageInput.internalTextView.GetRegionText("right"))
-	selection := []rune(window.messageInput.internalTextView.GetRegionText("selection"))
-	window.messageInput.InsertCharacter([]rune(left), right, selection, '\n')
+	left := window.messageInput.internalTextView.GetRegionText("left")
+	right := window.messageInput.internalTextView.GetRegionText("right")
+	selection := window.messageInput.internalTextView.GetRegionText("selection")
+	if len(selection) == 1 {
+		window.messageInput.InsertCharacter([]rune(left), []rune(right), []rune(selection), '\n')
+	} else {
+		window.messageInput.SetText(left + "\n" + right)
+	}
 	window.app.QueueUpdateDraw(func() {
 		window.messageInput.triggerHeightRequestIfNeccessary()
 		window.messageInput.internalTextView.ScrollToHighlight()


### PR DESCRIPTION
Pressing enter inside a codeblock enclosure (triple grave markers ```) now inserts a new line instead of sending the message.

It is working well, but I am not sure if it has the exact same implementation as the official client.