### PR TITLE
Fd swapping at voice-support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ stage/
 prime/
 snap/.snapcraft
 .vscode/
+log.txt

--- a/app/app.go
+++ b/app/app.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Bios-Marcel/cordless/commands/commandimpls"
 	"github.com/Bios-Marcel/cordless/config"
 	"github.com/Bios-Marcel/cordless/ui"
+	"github.com/Bios-Marcel/cordless/ui/tcellutil"
 	"github.com/Bios-Marcel/discordgo"
 	"github.com/Bios-Marcel/tview"
 )
@@ -49,6 +50,11 @@ func Run() {
 	}
 
 	app := tview.NewApplication()
+	screen, err := tcellutil.NewScreen()
+	if err != nil {
+		log.Fatalf("Unable to create TUI screen (%s)\n", err.Error())
+	}
+	app.SetScreen(screen)
 	splashScreen := tview.NewTextView()
 	splashScreen.SetTextAlign(tview.AlignCenter)
 	splashScreen.SetText(tview.Escape(splashText + "\n\nConfig lies at: " + configDir))

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Bios-Marcel/goclipimg v0.0.0-20190417192721-b58a8831f27d
 	github.com/Bios-Marcel/shortnotforlong v0.0.0-20190220133053-9074a923cf4d
 	github.com/Bios-Marcel/tview v0.0.0-20190712142836-ea9b4a50a84f
-	github.com/MOZGIII/fdswap-go v0.1.0
+	github.com/MOZGIII/fdswap-go v0.2.0
 	github.com/alecthomas/chroma v0.6.3
 	github.com/atotto/clipboard v0.1.2
 	github.com/chzyer/logex v1.1.10 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Bios-Marcel/goclipimg v0.0.0-20190417192721-b58a8831f27d
 	github.com/Bios-Marcel/shortnotforlong v0.0.0-20190220133053-9074a923cf4d
 	github.com/Bios-Marcel/tview v0.0.0-20190712142836-ea9b4a50a84f
+	github.com/MOZGIII/fdswap-go v0.1.0
 	github.com/alecthomas/chroma v0.6.3
 	github.com/atotto/clipboard v0.1.2
 	github.com/chzyer/logex v1.1.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/Bios-Marcel/tview v0.0.0-20190712142836-ea9b4a50a84f h1:BAqDSUAdafJsX
 github.com/Bios-Marcel/tview v0.0.0-20190712142836-ea9b4a50a84f/go.mod h1:1yM6ZD3hxlpiHugsW1MuABv9x42KTvxFUocQ4uEorN0=
 github.com/DATA-DOG/go-sqlmock v1.3.3 h1:CWUqKXe0s8A2z6qCgkP4Kru7wC11YoAnoupUKFDnH08=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
+github.com/MOZGIII/fdswap-go v0.1.0 h1:GuxinRn0VL4kFpPpMzm3fSOBrlVgkpjhFqJ05rfxISA=
+github.com/MOZGIII/fdswap-go v0.1.0/go.mod h1:xIkiiZzOjzDXCWQ2/Q5ZIaI13Z74tfVljNrhbVepuiQ=
 github.com/alecthomas/assert v0.0.0-20170929043011-405dbfeb8e38 h1:smF2tmSOzy2Mm+0dGI2AIUHY+w0BUc+4tn40djz7+6U=
 github.com/alecthomas/assert v0.0.0-20170929043011-405dbfeb8e38/go.mod h1:r7bzyVFMNntcxPZXK3/+KdruV1H5KSlyVY0gc+NgInI=
 github.com/alecthomas/chroma v0.6.3 h1:8H1D0yddf0mvgvO4JDBKnzLd9ERmzzAijBxnZXGV/FA=

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/DATA-DOG/go-sqlmock v1.3.3 h1:CWUqKXe0s8A2z6qCgkP4Kru7wC11YoAnoupUKFD
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/MOZGIII/fdswap-go v0.1.0 h1:GuxinRn0VL4kFpPpMzm3fSOBrlVgkpjhFqJ05rfxISA=
 github.com/MOZGIII/fdswap-go v0.1.0/go.mod h1:xIkiiZzOjzDXCWQ2/Q5ZIaI13Z74tfVljNrhbVepuiQ=
+github.com/MOZGIII/fdswap-go v0.2.0 h1:OJPUAioRBrbwKzuSRGc+4hkTcloknD7f3x99gzYN5x0=
+github.com/MOZGIII/fdswap-go v0.2.0/go.mod h1:xIkiiZzOjzDXCWQ2/Q5ZIaI13Z74tfVljNrhbVepuiQ=
 github.com/alecthomas/assert v0.0.0-20170929043011-405dbfeb8e38 h1:smF2tmSOzy2Mm+0dGI2AIUHY+w0BUc+4tn40djz7+6U=
 github.com/alecthomas/assert v0.0.0-20170929043011-405dbfeb8e38/go.mod h1:r7bzyVFMNntcxPZXK3/+KdruV1H5KSlyVY0gc+NgInI=
 github.com/alecthomas/chroma v0.6.3 h1:8H1D0yddf0mvgvO4JDBKnzLd9ERmzzAijBxnZXGV/FA=

--- a/ui/fdwscreen/impl_noswap.go
+++ b/ui/fdwscreen/impl_noswap.go
@@ -1,0 +1,15 @@
+// +build !linux,!darwin!,!netbsd,!openbsd
+
+package fdwscreen
+
+type fdSwapper struct{}
+
+func newFdSwapper() (*fdSwapper, error) {
+	return nil, nil
+}
+
+func (s *fdSwapper) InitSwap() {
+}
+
+func (s *fdSwapper) FiniSwap() {
+}

--- a/ui/fdwscreen/impl_swap.go
+++ b/ui/fdwscreen/impl_swap.go
@@ -1,0 +1,83 @@
+// +build linux darwin netbsd openbsd
+
+package fdwscreen
+
+import (
+	"os"
+
+	"github.com/MOZGIII/fdswap-go"
+)
+
+type fdSwapper struct {
+	logFilePath string
+
+	logFile *os.File
+
+	swappedFdHandleStdout *fdswap.SwappedFdHandle
+	swappedFdHandleStderr *fdswap.SwappedFdHandle
+}
+
+func newFdSwapper() (*fdSwapper, error) {
+	logFilePath := os.Getenv("CORDLESS_LOG_FILE_PATH")
+	if logFilePath == "" {
+		// TODO: use more sensible default.
+		logFilePath = "log.txt"
+	}
+
+	return &fdSwapper{
+		logFilePath: logFilePath,
+
+		logFile: nil,
+
+		swappedFdHandleStdout: nil,
+		swappedFdHandleStderr: nil,
+	}, nil
+}
+
+func (s *fdSwapper) InitSwap() {
+	s.clear()
+
+	var err error
+
+	s.logFile, err = os.OpenFile(s.logFilePath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
+	if err != nil {
+		panic(err)
+	}
+
+	s.swappedFdHandleStdout, err = fdswap.SwapFiles(os.Stdout, s.logFile)
+	if err != nil {
+		panic(err)
+	}
+
+	s.swappedFdHandleStderr, err = fdswap.SwapFiles(os.Stderr, s.logFile)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (s *fdSwapper) FiniSwap() {
+	s.clear()
+}
+
+func (s *fdSwapper) clear() {
+	if s.swappedFdHandleStdout != nil {
+		if err := s.swappedFdHandleStdout.Restore(); err != nil {
+			panic(err)
+		}
+		s.swappedFdHandleStdout = nil
+	}
+
+	if s.swappedFdHandleStderr != nil {
+		if err := s.swappedFdHandleStderr.Restore(); err != nil {
+			panic(err)
+		}
+		s.swappedFdHandleStderr = nil
+	}
+
+	if s.logFile != nil {
+		if err := s.logFile.Close(); err != nil {
+			panic(err)
+		}
+		s.logFile = nil
+	}
+}

--- a/ui/fdwscreen/screen.go
+++ b/ui/fdwscreen/screen.go
@@ -1,0 +1,41 @@
+package fdwscreen
+
+import (
+	"github.com/gdamore/tcell"
+)
+
+// FdSwappingScreen wraps tcell.Screen with a fd-swapping mechanism.
+type FdSwappingScreen struct {
+	tcell.Screen
+	swapper *fdSwapper
+}
+
+var _ tcell.Screen = (*FdSwappingScreen)(nil)
+
+// Init initializes the screen for use.
+func (s *FdSwappingScreen) Init() error {
+	if s.swapper != nil {
+		s.swapper.InitSwap()
+	}
+	return s.Screen.Init()
+}
+
+// Fini finalizes the screen also releasing resources.
+func (s *FdSwappingScreen) Fini() {
+	s.Screen.Fini()
+	if s.swapper != nil {
+		s.swapper.FiniSwap()
+	}
+}
+
+// NewFdSwappingScreen wraps tcell.Screen with a fd-swapping mechanism.
+func NewFdSwappingScreen(s tcell.Screen) (*FdSwappingScreen, error) {
+	swapper, err := newFdSwapper()
+	if err != nil {
+		return nil, err
+	}
+	return &FdSwappingScreen{
+		Screen:  s,
+		swapper: swapper,
+	}, nil
+}

--- a/ui/tcellutil/screen.go
+++ b/ui/tcellutil/screen.go
@@ -1,0 +1,26 @@
+package tcellutil
+
+import (
+	"fmt"
+
+	"github.com/Bios-Marcel/cordless/ui/fdwscreen"
+	"github.com/gdamore/tcell"
+)
+
+func NewScreen() (tcell.Screen, error) {
+	screen, err := tcell.NewScreen()
+	if err != nil {
+		return nil, fmt.Errorf("screen creation error: %v", err)
+	}
+
+	screen, err = fdwscreen.NewFdSwappingScreen(screen)
+	if err != nil {
+		return nil, fmt.Errorf("fd-wrapping screen creation error: %v", err)
+	}
+
+	if err := screen.Init(); err != nil {
+		return nil, fmt.Errorf("initialization error: %v", err)
+	}
+
+	return screen, nil
+}


### PR DESCRIPTION
This change allows us to capture stdout and stderr to file, which prevents
the TUI screen corruption.