### PR TITLE
Fixed a simple spelling mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ $ trizen -S cordless-git
 
 ###### pacaur
 ```shell
-$ pacuar -S cordless-git
+$ pacaur -S cordless-git
 ```
 
 ### Installing on Windows


### PR DESCRIPTION
its in the name. :p

pacuar -S cordless-git -> pacaur -S cordless-git
for the arch install command