### PR TITLE
Config dir is now created on first run.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ $ trizen -S cordless-git
 
 ###### pacaur
 ```shell
-$ pacuar -S cordless-git
+$ pacaur -S cordless-git
 ```
 
 ### Installing on Windows

--- a/commands/commandimpls/user.go
+++ b/commands/commandimpls/user.go
@@ -71,7 +71,7 @@ const (
 
 [::b]DESCRIPTION
 	This command prints your accounts user information to the
-	commandline ina human readable format. If no options were
+	commandline in a human readable format. If no options were
 	supplied, then "-n", "-e" and "-a" are chosen as the default
 	options.
 

--- a/config/config.go
+++ b/config/config.go
@@ -229,6 +229,7 @@ func SetConfigDirectory(directoryPath string) error {
 	}
 	return err
 }
+
 // GetConfigDirectory retrieves the directory that stores
 // cordless' settings from cache or sets it to the default
 // location
@@ -261,7 +262,7 @@ func ensureDirectory(directoryPath string) error {
 			return createDirsError
 		}
 	}
-	return statError
+	return nil
 }
 
 func getAbsolutePath(directoryPath string) (string, error) {

--- a/config/config.go
+++ b/config/config.go
@@ -261,8 +261,9 @@ func ensureDirectory(directoryPath string) error {
 		if createDirsError != nil {
 			return createDirsError
 		}
+		return nil
 	}
-	return nil
+	return statError
 }
 
 func getAbsolutePath(directoryPath string) (string, error) {

--- a/cordless.json
+++ b/cordless.json
@@ -2,8 +2,17 @@
 	"homepage": "https://github.com/Bios-Marcel/cordless",
 	"description": "A third party discord client alternative.",
 	"license": "BSD-3-Clause",
-	"version": "2019-11-19",
-	"url": "https://github.com/Bios-Marcel/cordless/releases/download/2019-11-19/cordless.exe",
-	"bin": "cordless.exe",
-	"hash": "894ffb455e549010681005b1f25ec7c1ded9bd9f0cf28ce668dc759ce6432d21"
+	"version": "2020-01-05",
+	"architecture": {
+		"64bit": {
+			"url": "https://github.com/Bios-Marcel/cordless/releases/download/2020-01-05/cordless_64.exe",
+			"bin": [ ["cordless_64.exe", "cordless"] ],
+			"hash": "d1ac92205cc71e27335e323758952bbbe9ed7f25bc73cbf5a6086f9e35555e9c"
+		},
+		"32bit": {
+			"url": "https://github.com/Bios-Marcel/cordless/releases/download/2020-01-05/cordless_32.exe",
+			"bin": [ ["cordless_32.exe", "cordless"] ],
+			"hash": "b662fc0cbd69ef1ddcd986c3e515bda09e5b0210768f7532b1c5626b1c5d09be"
+		}
+	}
 }

--- a/version/version.go
+++ b/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-var Version = "2019-11-19"
+var Version = "2020-01-05"


### PR DESCRIPTION
Fixes #238 

## What Changed
[config.go ensureDirectory](https://github.com/Bios-Marcel/cordless/blob/d8964d99d0f3e3ab60c42d2f551e7543349dc9d8/config/config.go#L256) was throwing an error when the directory did not exist, but was properly created. It now returns `nil` instead.

I've tested the change locally (linux only) and everything is working fine.

I would suggest making a new release so this change takes effect as soon as possible, as it could turn away new users even before the program is used.