### PR TITLE
Show message input box in bare mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ $ trizen -S cordless-git
 
 ###### pacaur
 ```shell
-$ pacuar -S cordless-git
+$ pacaur -S cordless-git
 ```
 
 ### Installing on Windows

--- a/commands/commandimpls/user.go
+++ b/commands/commandimpls/user.go
@@ -71,7 +71,7 @@ const (
 
 [::b]DESCRIPTION
 	This command prints your accounts user information to the
-	commandline ina human readable format. If no options were
+	commandline in a human readable format. If no options were
 	supplied, then "-n", "-e" and "-a" are chosen as the default
 	options.
 

--- a/cordless.json
+++ b/cordless.json
@@ -2,8 +2,17 @@
 	"homepage": "https://github.com/Bios-Marcel/cordless",
 	"description": "A third party discord client alternative.",
 	"license": "BSD-3-Clause",
-	"version": "2019-11-19",
-	"url": "https://github.com/Bios-Marcel/cordless/releases/download/2019-11-19/cordless.exe",
-	"bin": "cordless.exe",
-	"hash": "894ffb455e549010681005b1f25ec7c1ded9bd9f0cf28ce668dc759ce6432d21"
+	"version": "2020-01-05",
+	"architecture": {
+		"64bit": {
+			"url": "https://github.com/Bios-Marcel/cordless/releases/download/2020-01-05/cordless_64.exe",
+			"bin": [ ["cordless_64.exe", "cordless"] ],
+			"hash": "d1ac92205cc71e27335e323758952bbbe9ed7f25bc73cbf5a6086f9e35555e9c"
+		},
+		"32bit": {
+			"url": "https://github.com/Bios-Marcel/cordless/releases/download/2020-01-05/cordless_32.exe",
+			"bin": [ ["cordless_32.exe", "cordless"] ],
+			"hash": "b662fc0cbd69ef1ddcd986c3e515bda09e5b0210768f7532b1c5626b1c5d09be"
+		}
+	}
 }

--- a/ui/window.go
+++ b/ui/window.go
@@ -2186,18 +2186,17 @@ func (window *Window) toggleUserContainer() {
 	window.RefreshLayout()
 }
 
-// toggleBareChat will display only the chatview as the fullscreen application
-// root. Calling this method again will revert the view to it's normal state.
+// toggleBareChat will display only the chatview and messageInput.
+// Calling this method again will revert the view to it's normal state.
 func (window *Window) toggleBareChat() {
 	window.bareChat = !window.bareChat
+	window.chatView.internalTextView.SetBorder(!window.bareChat)
+	window.leftArea.SetVisible(!window.bareChat)
+	window.userList.internalTreeView.SetVisible(!window.bareChat)
+
+	// Automatically focus the message input when bare mode is enabled.
 	if window.bareChat {
-		window.chatView.internalTextView.SetBorder(false)
-		window.currentContainer = window.chatView.GetPrimitive()
-		window.app.SetRoot(window.chatView.GetPrimitive(), true)
-	} else {
-		window.chatView.internalTextView.SetBorder(true)
-		window.currentContainer = window.rootContainer
-		window.app.SetRoot(window.rootContainer, true)
+		window.app.SetFocus(window.messageInput.GetPrimitive())
 	}
 }
 

--- a/version/version.go
+++ b/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-var Version = "2019-11-19"
+var Version = "2020-01-05"


### PR DESCRIPTION
Closes #219 

I've changed the way components are hidden, simply by making them invisible while in bare mode. This allows for navigation of those hidden components, but I personally don't see anything wrong with it.

The message input box is visible in this PR (always), but we could add an option to toggle it if anyone thinks it's necessary. The message input box is auto-focused when entering bare mode.

Note, the extra commits in this PR were caused by a force push to cordless after I forked the project. Should be easy to re-implement if we want to clean it up.