### PR TITLE
Add hotkey to open message's image attachments in feh

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -56,6 +56,7 @@ var (
 		ShowUpdateNotifications:                true,
 		IndicateChannelAccessRestriction:       false,
 		ShowBottomBar:                          true,
+		ImageViewer:                            "feh",
 	}
 )
 
@@ -133,6 +134,12 @@ type Config struct {
 	// ShowBottomBar decides whether an informational line is shown at the
 	// bottom of cordless or not.
 	ShowBottomBar bool
+
+	// The image viewer to open when the user uses the "view attached images"
+	// shortcut. This program will be passed a list of 1 or more image links
+	// as if it were called from the command line, so the selected program
+	// must be capable of opening image links.
+	ImageViewer string
 }
 
 // Account has a name and a token. The name is just for the users recognition.

--- a/shortcuts/shortcuts.go
+++ b/shortcuts/shortcuts.go
@@ -31,7 +31,7 @@ var (
 		chatview, tcell.NewEventKey(tcell.KeyRune, 's', tcell.ModNone))
 	DeleteSelectedMessage = addShortcut("toggle_selected_message_spoilers", "Toggle spoilers in selected message",
 		chatview, tcell.NewEventKey(tcell.KeyDelete, 0, tcell.ModNone))
-	ViewSelectedMessageImages = addShortcut("view_selected_message_images", "Open selected message's attached images in feh",
+	ViewSelectedMessageImages = addShortcut("view_selected_message_images", "View selected message's attached images",
 		chatview, tcell.NewEventKey(tcell.KeyRune, 'o', tcell.ModNone))
 
 	ExpandSelectionToLeft = addShortcut("expand_selection_word_to_left", "Expand selection word to left",

--- a/shortcuts/shortcuts.go
+++ b/shortcuts/shortcuts.go
@@ -31,6 +31,8 @@ var (
 		chatview, tcell.NewEventKey(tcell.KeyRune, 's', tcell.ModNone))
 	DeleteSelectedMessage = addShortcut("toggle_selected_message_spoilers", "Toggle spoilers in selected message",
 		chatview, tcell.NewEventKey(tcell.KeyDelete, 0, tcell.ModNone))
+	ViewSelectedMessageImages = addShortcut("view_selected_message_images", "Open selected message's attached images in feh",
+		chatview, tcell.NewEventKey(tcell.KeyRune, 'o', tcell.ModNone))
 
 	ExpandSelectionToLeft = addShortcut("expand_selection_word_to_left", "Expand selection word to left",
 		multilineTextInput, tcell.NewEventKey(tcell.KeyLeft, 0, tcell.ModShift))

--- a/ui/window.go
+++ b/ui/window.go
@@ -392,7 +392,7 @@ func NewWindow(doRestart chan bool, app *tview.Application, session *discordgo.S
 				links = append(links, file.URL)
 			}
 			if len(links) > 0 {
-				cmd := exec.Command("feh", links...)
+				cmd := exec.Command(config.Current.ImageViewer, links...)
 				err := cmd.Start()
 				if err != nil {
 					window.ShowErrorDialog(err.Error())

--- a/ui/window.go
+++ b/ui/window.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 	"unicode"
+	"os/exec"
 
 	"github.com/mattn/go-runewidth"
 	"github.com/mdp/qrterminal/v3"
@@ -382,6 +383,22 @@ func NewWindow(doRestart chan bool, app *tview.Application, session *discordgo.S
 			if copyError != nil {
 				window.ShowErrorDialog(fmt.Sprintf("Error copying message: %s", copyError.Error()))
 			}
+			return nil
+		}
+
+		if shortcuts.ViewSelectedMessageImages.Equals(event) {
+			links := make([]string, 0, len(message.Attachments))
+			for _, file := range message.Attachments {
+				links = append(links, file.URL)
+			}
+			if len(links) > 0 {
+				cmd := exec.Command("feh", links...)
+				err := cmd.Start()
+				if err != nil {
+					window.ShowErrorDialog(err.Error())
+				}
+			}
+
 			return nil
 		}
 


### PR DESCRIPTION
[feh](https://wiki.archlinux.org/index.php/Feh) is a lightweight and powerful image viewer. This PR adds a hotkey which opens all of a message's image attachments in feh. The hotkey is mapped to 'o' by default.

Select a message that has attached image(s) and press 'o', then the image(s) will be opened for viewing in feh. This negates the need to copy/paste the attachment links into a web browser. feh will simply ignore any file types it is passed that it doesn't support (such as mp4, etc).

This feature requires feh to be installed. If feh is not installed and the user attempts to use this feature, a graceful error dialog will be displayed.

Note that this feature only handles actual image attachments - it will not process image links that are pasted directly into the chat bar and sent. Those types of links will still need to be manually copy+pasted into a browser.