### PR TITLE
Add Dockerfile for building a Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:latest
+
+WORKDIR /go/src/cordless
+
+COPY . ./
+
+RUN go build .
+
+VOLUME ["/root/.config/cordless"]
+
+ENTRYPOINT ["/go/src/cordless/cordless"]
+


### PR DESCRIPTION
Docker image can be built with:

`docker build -t cordless:latest .`

Container can then be run with:

`docker run -it --rm -v $HOME/.config/cordless:/root/.config/cordless cordless:latest`
