### PR TITLE
Fix typo

### DIFF
--- a/config/os.go
+++ b/config/os.go
@@ -9,7 +9,7 @@ import (
 )
 
 func getDefaultConfigDirectory() (string, error) {
-	configDir := os.Getenv("XDG_CONFIG_DIR")
+	configDir := os.Getenv("XDG_CONFIG_HOME")
 
 	if configDir != "" {
 		return configDir, nil


### PR DESCRIPTION
Change `XDG_CONFIG_DIR` to `XDG_CONFIG_HOME`.
Closes #249.