### PR TITLE
Add the extension to shortened urls

### DIFF
--- a/commands/commandimpls/manual.go
+++ b/commands/commandimpls/manual.go
@@ -335,6 +335,13 @@ const configurationDocumentation = `[::b]TOPIC
 		
 		Type:    boolean
 		Default: false
+
+	[::b]ShortenWithExtension
+		Determines wether the suffix is added to the shortened url. This
+		setting only matters if [::b]ShortenLinks[::-] is set to [::b]true[::-]
+
+		Type:    boolean
+		Default: false
 		
 	[::b]ShortenerPort
 		Determines which port the link-shortener uses in your system. This

--- a/config/config.go
+++ b/config/config.go
@@ -49,6 +49,7 @@ var (
 		OnTypeInListBehaviour:                  SearchOnTypeInList,
 		MouseEnabled:                           true,
 		ShortenLinks:                           false,
+		ShortenWithExtension:                   false,
 		ShortenerPort:                          63212,
 		DesktopNotifications:                   true,
 		ShowPlaceholderForBlockedMessages:      true,
@@ -103,6 +104,9 @@ type Config struct {
 	// ShortenLinks decides whether cordless starts a local webserver in order
 	// to be able to shorten links
 	ShortenLinks bool
+	// ShortenWithExtension defines wether the suffix is added to the shortened
+	// url
+	ShortenWithExtension bool
 	// ShortenerPort defines the port, that the webserver for the linkshortener
 	// will be using.
 	ShortenerPort int

--- a/go.mod
+++ b/go.mod
@@ -2,12 +2,13 @@ module github.com/Bios-Marcel/cordless
 
 go 1.12
 
+
 require (
 	github.com/Bios-Marcel/discordemojimap v1.0.1
 	github.com/Bios-Marcel/discordgo v0.21.2-0.20200623171446-e58d0f4fd815
 	github.com/Bios-Marcel/femto v0.0.0-20200222161014-a3b2d5718b2d
 	github.com/Bios-Marcel/goclipimg v0.0.0-20191117180634-d0f7b06fbe82
-	github.com/Bios-Marcel/shortnotforlong v1.0.0
+	github.com/Bios-Marcel/shortnotforlong v0.0.0-20200321095947-aff277751d3a
 	github.com/Bios-Marcel/tview v0.0.0-20200222160847-9e022c4dffcd
 	github.com/alecthomas/chroma v0.6.6
 	github.com/atotto/clipboard v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/Bios-Marcel/femto v0.0.0-20200222161014-a3b2d5718b2d h1:Qp7lNPAsDTjYw
 github.com/Bios-Marcel/femto v0.0.0-20200222161014-a3b2d5718b2d/go.mod h1:fQUdoboAqEZnC3nRTFfsOGpyoS7PX6bHwRfbBLqmM78=
 github.com/Bios-Marcel/goclipimg v0.0.0-20191117180634-d0f7b06fbe82 h1:gspJ6CW9bhboosSISmuX2iq03pUsYHzlJN0s+z4fz4E=
 github.com/Bios-Marcel/goclipimg v0.0.0-20191117180634-d0f7b06fbe82/go.mod h1:hiFR6fH5+uc/f2yK2syh/UfzaPfGo6F2HJSoiI4ufWU=
-github.com/Bios-Marcel/shortnotforlong v1.0.0 h1:K4JJ5U3+D8LXoAiH0QbfMujWuqKo+NAEZKuQ2RHPqqE=
-github.com/Bios-Marcel/shortnotforlong v1.0.0/go.mod h1:g6bFiwq0pq7pqENRgHiCZu7uMzeYPIXwANlaBQ47LBw=
+github.com/Bios-Marcel/shortnotforlong v0.0.0-20200321095947-aff277751d3a h1:myIaPf5yD2eGY77dH4pcLDqNMr7etyY5tpawL8D790o=
+github.com/Bios-Marcel/shortnotforlong v0.0.0-20200321095947-aff277751d3a/go.mod h1:g6bFiwq0pq7pqENRgHiCZu7uMzeYPIXwANlaBQ47LBw=
 github.com/Bios-Marcel/tview v0.0.0-20200222160847-9e022c4dffcd h1:PHsKXsC27RNkoyk257KV/yyuEimaPJiMavm0Z0ktE8E=
 github.com/Bios-Marcel/tview v0.0.0-20200222160847-9e022c4dffcd/go.mod h1:LI4Pwi1HXdNKIxks12tMt5stClEHfvpKpTL9uEotslI=
 github.com/GeertJohan/go.incremental v1.0.0/go.mod h1:6fAjUhbVuX1KcMD3c8TEgVUqmo4seqhv0i0kdATSkM0=


### PR DESCRIPTION
The presence of the extension is controlled by a config option
I also bumped the shortnotforlong version to the latest commit changing the api.
