### PR TITLE
GuildStore Channels now appear in channeltree

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -137,6 +137,10 @@ type Config struct {
 
 	// Show a padlock prefix of the channels that have access restriction
 	IndicateChannelAccessRestriction bool
+
+    // Show hidden channels
+	ShowHiddenChannels bool
+
 	// ShowBottomBar decides whether an informational line is shown at the
 	// bottom of cordless or not.
 	ShowBottomBar bool
@@ -205,6 +209,7 @@ func createDefaultConfig() *Config {
 		ShowPlaceholderForBlockedMessages:           true,
 		DontShowUpdateNotificationFor:               "",
 		ShowUpdateNotifications:                     true,
+		ShowHiddenChannels:                          false,
 		IndicateChannelAccessRestriction:            false,
 		ShowBottomBar:                               true,
 		ShowNicknames:                               true,

--- a/discordutil/channel.go
+++ b/discordutil/channel.go
@@ -81,9 +81,11 @@ func SortPrivateChannels(channels []*discordgo.Channel) {
 // specific channel.
 func HasReadMessagesPermission(channelID string, state *discordgo.State) bool {
 	userPermissions, err := state.UserChannelPermissions(state.User.ID, channelID)
-	if err != nil {
-		// Unable to access channel permissions.
-		return false
+	if config.Current.ShowHiddenChannels {
+		if err == nil {
+			// Unable to access channel permissions.
+			return true
+		}
 	}
 	return (userPermissions & discordgo.PermissionViewChannel) > 0
 }

--- a/discordutil/channel.go
+++ b/discordutil/channel.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 	"strconv"
 
+	"github.com/Bios-Marcel/cordless/config"
+
 	"github.com/Bios-Marcel/discordgo"
 
 	"github.com/Bios-Marcel/cordless/ui/tviewutil"

--- a/ui/channeltree.go
+++ b/ui/channeltree.go
@@ -104,7 +104,7 @@ func (channelTree *ChannelTree) LoadGuild(guildID string) error {
 	// Top level channel
 	state := channelTree.state
 	for _, channel := range channels {
-		if (channel.Type != discordgo.ChannelTypeGuildText && channel.Type != discordgo.ChannelTypeGuildNews) ||
+		if (channel.Type != discordgo.ChannelTypeGuildText && channel.Type != discordgo.ChannelTypeGuildNews && channel.Type != discordgo.ChannelTypeGuildStore) ||
 			channel.ParentID != "" || !discordutil.HasReadMessagesPermission(channel.ID, state) {
 			continue
 		}
@@ -137,7 +137,7 @@ CATEGORY_LOOP:
 	}
 	// Second level channel
 	for _, channel := range channels {
-		if (channel.Type != discordgo.ChannelTypeGuildText && channel.Type != discordgo.ChannelTypeGuildNews) ||
+		if (channel.Type != discordgo.ChannelTypeGuildText && channel.Type != discordgo.ChannelTypeGuildNews && channel.Type != discordgo.ChannelTypeGuildStore) ||
 			channel.ParentID == "" || !discordutil.HasReadMessagesPermission(channel.ID, state) {
 			continue
 		}

--- a/ui/channeltree.go
+++ b/ui/channeltree.go
@@ -192,6 +192,15 @@ func createChannelNode(channel *discordgo.Channel) *tview.TreeNode {
 	if channel.NSFW {
 		prefixes += tviewutil.Escape("🔞")
 	}
+	if channel.Type == discordgo.ChannelTypeGuildNews {
+		prefixes += tviewutil.Escape("🎺")
+	}
+	if channel.Type == discordgo.ChannelTypeGuildStore {
+		prefixes += tviewutil.Escape("💳")
+	}
+	if channel.Type == discordgo.ChannelTypeGuildCategory {
+		prefixes += tviewutil.Escape("📊")
+	}
 
 	// Adds a padlock prefix if the channel if not readable by the everyone group
 	if config.Current.IndicateChannelAccessRestriction {

--- a/ui/privatechats.go
+++ b/ui/privatechats.go
@@ -142,6 +142,15 @@ func (privateList *PrivateChatList) addChannel(channel *discordgo.Channel) {
 
 func createPrivateChannelNode(channel *discordgo.Channel) *tview.TreeNode {
 	channelNode := tview.NewTreeNode(discordutil.GetPrivateChannelName(channel))
+	var prefixes string
+	if channel.Type == discordgo.ChannelTypeDM {
+		prefixes += tviewutil.Escape("🧑")
+	}
+	if channel.Type == discordgo.ChannelTypeGroupDM {
+		prefixes += tviewutil.Escape("🧑🧑🧑")
+	}
+	channelNode.SetPrefix(prefixes)
+	
 	channelNode.SetReference(channel.ID)
 	return channelNode
 }


### PR DESCRIPTION
**Example of Emojis**
![image](https://user-images.githubusercontent.com/10566724/91975379-3ce6a280-ed17-11ea-84f6-2bf12dcef29b.png)
Added Emoji's to tell different channel types apart such as Announcement Channels and Store Channels

**Example of Hidden Channels being turned on, it is turned off in above screenshot**
![image](https://user-images.githubusercontent.com/10566724/91975504-67d0f680-ed17-11ea-8c60-fe3b5af91e33.png)
Show hidden channels config option allows turning on/off the visibility of channels you can't normally see


p.s 
Couldn't get my commits to be in separate pull requests as each commit keeps adding to the existing request