### PR TITLE
Added chat seperator between Message Author and Message Body

### DIFF
--- a/ui/chatview.go
+++ b/ui/chatview.go
@@ -442,7 +442,7 @@ func (chatView *ChatView) formatMessageAuthor(message *discordgo.Message) string
 		userColor = discordutil.GetUserColor(message.Author)
 	}
 
-	return "[::b][" + userColor + "]" + messageAuthor + "[::-]"
+	return "[::b][" + userColor + "]" + messageAuthor + ":" + "[::-]"
 }
 
 func (chatView *ChatView) formatMessageText(message *discordgo.Message) string {

--- a/ui/chatview.go
+++ b/ui/chatview.go
@@ -442,7 +442,7 @@ func (chatView *ChatView) formatMessageAuthor(message *discordgo.Message) string
 		userColor = discordutil.GetUserColor(message.Author)
 	}
 
-	return "[::b][" + userColor + "]" + messageAuthor + ":" + "[::-]"
+	return "[::b][" + userColor + "]" + messageAuthor + ":[::-]"
 }
 
 func (chatView *ChatView) formatMessageText(message *discordgo.Message) string {


### PR DESCRIPTION
**Example of Author/Message separator**
![image](https://user-images.githubusercontent.com/10566724/92099689-b98a8700-edd2-11ea-8fa3-7c1a3df32fd5.png)

PR adds a : between the username and message in chatview so t doesn't blend in