### PR TITLE
Refactor to support a future new chat view

### DIFF
--- a/ui/channeltree.go
+++ b/ui/channeltree.go
@@ -37,6 +37,8 @@ func checkVT() bool {
 
 var vtxxx = checkVT()
 
+var _ Focusable = (*ChannelTree)(nil)
+
 // ChannelTree is the component that displays the channel hierarchy of the
 // currently loaded guild and allows interactions with those channels.
 type ChannelTree struct {

--- a/ui/channeltree.go
+++ b/ui/channeltree.go
@@ -414,3 +414,10 @@ func (channelTree *ChannelTree) Lock() {
 func (channelTree *ChannelTree) Unlock() {
 	channelTree.mutex.Unlock()
 }
+
+// Focus tells a UI component to change the focus
+// of the given application to itself
+// Implements Focusable
+func (channelTree *ChannelTree) SetFocus(app *tview.Application) {
+	app.SetFocus(channelTree)
+}

--- a/ui/chatview.go
+++ b/ui/chatview.go
@@ -48,6 +48,68 @@ var (
 	roleMentionRegex           = regexp.MustCompile(`<@&\d*>`)
 )
 
+// OnMessageAction represents the handler that will get called 
+// if the user tries to interact with a selected message.
+type OnMessageAction = func(message *discordgo.Message, event *tcell.EventKey) *tcell.EventKey
+
+// ChatViewInterface is the interface which collaborators 
+// of a chat view depend on
+type ChatViewInterface interface {
+	//AddMessage add an additional message to the ChatView.
+	AddMessage(message *discordgo.Message)
+
+	// ClearSelection clears the current selection of messages.	
+	ClearSelection()
+
+	// ClearViewAndCache clears the TextView buffer and removes all data for
+	// all messages.	
+	ClearViewAndCache()
+
+	// DeleteMessage drops the message from the cache and triggers a reprint
+	DeleteMessage(deletedMessage *discordgo.Message)
+
+	// DeleteMessages drops the messages from the cache and triggers a reprint
+	DeleteMessages(deletedMessages []string)
+
+	// GetPrimitive returns the component that can be added to a layout, since
+	// the ChatView itself is not a component.
+	GetPrimitive() tview.Primitive
+
+	// Lock will lock the ChatView, allowing other callers to prevent race
+	// conditions.
+	Lock()
+
+	// Reprint clears the internal TextView and prints all currently cached
+	// messages into the internal TextView again. This will not actually cause a
+	// redraw in the user interface. This would still only be done by
+	// ForceDraw, QueueUpdateDraw or user events. Calling this method is
+	// necessary if previously added content has changed or has been removed, since
+	// can only append to the TextViews buffers, but not cut parts out.
+	Reprint()
+
+	// SignalSelectionDeleted notifies the ChatView that its currently selected
+	// message doesn't exist anymore, moving the selection up by a row if possible.	
+	SignalSelectionDeleted()
+
+	// SetMessages defines all currently displayed messages. Parsing and
+	// manipulation of single message elements happens in this function.	
+	SetMessages(messages []*discordgo.Message)
+
+	// SetOnMessageAction sets the handler that will get called if the user tries
+	// to interact with a selected message.
+	SetOnMessageAction(onMessageAction OnMessageAction)
+
+	// SetTitle sets the border text of the chatview.
+	SetTitle(text string)
+
+	// Unlock unlocks the previously locked ChatView.	
+	Unlock()
+
+	// UpdateMessage reformats the passed message, updates the cache and triggers
+	// a reprint.
+	UpdateMessage(updatedMessage *discordgo.Message)
+}
+
 // ChatView is using a tview.TextView in order to be able to display messages
 // in a simple way. It supports highlighting specific element types and it
 // also supports multiline.

--- a/ui/chatview.go
+++ b/ui/chatview.go
@@ -55,6 +55,8 @@ type OnMessageAction = func(message *discordgo.Message, event *tcell.EventKey) *
 // ChatViewInterface is the interface which collaborators 
 // of a chat view depend on
 type ChatViewInterface interface {
+	Focusable
+
 	//AddMessage add an additional message to the ChatView.
 	AddMessage(message *discordgo.Message)
 
@@ -1117,4 +1119,11 @@ func (chatView *ChatView) Lock() {
 // Unlock unlocks the previously locked ChatView.
 func (chatView *ChatView) Unlock() {
 	chatView.mutex.Unlock()
+}
+
+// Focus tells a UI component to change the focus
+// of the given application to itself
+// Implements Focusable
+func (chatView *ChatView) SetFocus(app *tview.Application) {
+	app.SetFocus(chatView.internalTextView)
 }

--- a/ui/chatview.go
+++ b/ui/chatview.go
@@ -48,11 +48,11 @@ var (
 	roleMentionRegex           = regexp.MustCompile(`<@&\d*>`)
 )
 
-// OnMessageAction represents the handler that will get called 
+// OnMessageAction represents the handler that will get called
 // if the user tries to interact with a selected message.
 type OnMessageAction = func(message *discordgo.Message, event *tcell.EventKey) *tcell.EventKey
 
-// ChatViewInterface is the interface which collaborators 
+// ChatViewInterface is the interface which collaborators
 // of a chat view depend on
 type ChatViewInterface interface {
 	Focusable
@@ -60,11 +60,11 @@ type ChatViewInterface interface {
 	//AddMessage add an additional message to the ChatView.
 	AddMessage(message *discordgo.Message)
 
-	// ClearSelection clears the current selection of messages.	
+	// ClearSelection clears the current selection of messages.
 	ClearSelection()
 
 	// ClearViewAndCache clears the TextView buffer and removes all data for
-	// all messages.	
+	// all messages.
 	ClearViewAndCache()
 
 	// DeleteMessage drops the message from the cache and triggers a reprint
@@ -124,7 +124,7 @@ type ChatViewInterface interface {
 	ScrollUp()
 
 	// SignalSelectionDeleted notifies the ChatView that its currently selected
-	// message doesn't exist anymore, moving the selection up by a row if possible.	
+	// message doesn't exist anymore, moving the selection up by a row if possible.
 	SignalSelectionDeleted()
 
 	// SetBorderSides sets which borders should on the chat view should be shown,
@@ -135,7 +135,7 @@ type ChatViewInterface interface {
 	SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey)
 
 	// SetMessages defines all currently displayed messages. Parsing and
-	// manipulation of single message elements happens in this function.	
+	// manipulation of single message elements happens in this function.
 	SetMessages(messages []*discordgo.Message)
 
 	// SetMouseHandler sets the function which will handle mouse events
@@ -148,7 +148,7 @@ type ChatViewInterface interface {
 	// SetTitle sets the border text of the chatview.
 	SetTitle(text string)
 
-	// Unlock unlocks the previously locked ChatView.	
+	// Unlock unlocks the previously locked ChatView.
 	Unlock()
 
 	// UpdateMessage reformats the passed message, updates the cache and triggers
@@ -157,6 +157,7 @@ type ChatViewInterface interface {
 }
 
 var _ ChatViewInterface = (*ChatView)(nil)
+var _ Focusable = (*ChatView)(nil)
 
 // ChatView is using a tview.TextView in order to be able to display messages
 // in a simple way. It supports highlighting specific element types and it
@@ -1202,7 +1203,7 @@ func (chatView *ChatView) ScrollToEnd() {
 // for it to handle
 func (chatView *ChatView) HandleEvent(event *tcell.EventKey) {
 	handler := chatView.internalTextView.InputHandler()
-	handler(event, nil)	
+	handler(event, nil)
 }
 
 // GetMessages returns the messages that the chat view is able to show
@@ -1239,7 +1240,7 @@ func (chatView *ChatView) SetBorderSides(top, left, bottom, right bool) {
 
 // Dispose instructs the chat view to dispose of any resources it is
 // holding on to
-func (chatView *ChatView) Dispose() { 
+func (chatView *ChatView) Dispose() {
 	if chatView.shortenLinks {
 		chatView.shortener.Close()
 	}

--- a/ui/chatview.go
+++ b/ui/chatview.go
@@ -156,6 +156,8 @@ type ChatViewInterface interface {
 	UpdateMessage(updatedMessage *discordgo.Message)
 }
 
+var _ ChatViewInterface = (*ChatView)(nil)
+
 // ChatView is using a tview.TextView in order to be able to display messages
 // in a simple way. It supports highlighting specific element types and it
 // also supports multiline.

--- a/ui/chatview_test.go
+++ b/ui/chatview_test.go
@@ -10,6 +10,15 @@ import (
 	"github.com/Bios-Marcel/cordless/ui/tviewutil"
 )
 
+func TestChatViewImplementsChatViewInterface(t *testing.T) {
+	chatView := &ChatView{}
+	_, ok := interface{}(chatView).(ChatViewInterface)
+
+	if !ok {
+		t.Errorf("ChatView does not implement ChatViewInterface")
+	}
+}
+
 func TestParseBoldAndUnderline(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/ui/commandview.go
+++ b/ui/commandview.go
@@ -9,6 +9,8 @@ import (
 
 const noHistoryIndexSelected = -1
 
+var _ Focusable = (*CommandView)(nil)
+
 // CommandView contains a simple textview for output and an input field for
 // input. All commands are added to the history when confirmed via enter.
 type CommandView struct {

--- a/ui/commandview.go
+++ b/ui/commandview.go
@@ -187,3 +187,10 @@ func (cmdView *CommandView) Write(p []byte) (n int, err error) {
 
 	return
 }
+
+// Focus tells a UI component to change the focus
+// of the given application to itself
+// Implements Focusable
+func (cmdView *CommandView) SetFocus(app *tview.Application) {
+	app.SetFocus(cmdView.commandOutput)
+}

--- a/ui/editor.go
+++ b/ui/editor.go
@@ -628,3 +628,10 @@ func (editor *Editor) GetText() string {
 func (editor *Editor) GetPrimitive() tview.Primitive {
 	return editor.internalTextView
 }
+
+// Focus tells a UI component to change the focus
+// of the given application to itself
+// Implements Focusable
+func (editor *Editor) SetFocus(app *tview.Application) {
+	app.SetFocus(editor.GetPrimitive())
+}

--- a/ui/editor.go
+++ b/ui/editor.go
@@ -13,6 +13,8 @@ import (
 	"github.com/Bios-Marcel/cordless/ui/tviewutil"
 )
 
+var _ Focusable = (*Editor)(nil)
+
 // Editor is a simple component that wraps tview.TextView in order to give
 // the user minimal text edit functionality.
 type Editor struct {

--- a/ui/focusable.go
+++ b/ui/focusable.go
@@ -1,0 +1,12 @@
+package ui
+
+import (
+	"github.com/Bios-Marcel/cordless/tview"
+)
+
+// Focusable UI elements can be given focus
+type Focusable interface {
+	// Focus tells a UI component to change the focus
+	// of the given application to itself
+	SetFocus(app *tview.Application)
+}

--- a/ui/guildlist.go
+++ b/ui/guildlist.go
@@ -166,3 +166,10 @@ func (g *GuildList) amountOfUnreadGuilds() int {
 func (g *GuildList) UpdateUnreadGuildCount() {
 	g.setNotificationCount(g.amountOfUnreadGuilds())
 }
+
+// Focus tells a UI component to change the focus
+// of the given application to itself
+// Implements Focusable
+func (g *GuildList) SetFocus(app *tview.Application) {
+	app.SetFocus(g)
+}

--- a/ui/guildlist.go
+++ b/ui/guildlist.go
@@ -12,6 +12,8 @@ import (
 	"github.com/Bios-Marcel/cordless/ui/tviewutil"
 )
 
+var _ Focusable = (*GuildList)(nil)
+
 // GuildList is the UI component to hold all user guilds and allow loading
 // one of them.
 type GuildList struct {

--- a/ui/privatechats.go
+++ b/ui/privatechats.go
@@ -386,3 +386,10 @@ func (privateList *PrivateChatList) GetComponent() *tview.TreeView {
 func (privateList *PrivateChatList) SetInputCapture(capture func(event *tcell.EventKey) *tcell.EventKey) {
 	privateList.internalTreeView.SetInputCapture(capture)
 }
+
+// Focus tells a UI component to change the focus
+// of the given application to itself
+// Implements Focusable
+func (privateList *PrivateChatList) SetFocus(app *tview.Application) {
+	app.SetFocus(privateList.internalTreeView)
+}

--- a/ui/privatechats.go
+++ b/ui/privatechats.go
@@ -24,6 +24,8 @@ const (
 	read
 )
 
+var _ Focusable = (*PrivateChatList)(nil)
+
 // PrivateChatList holds the nodes and handlers for the private view. That
 // is the one responsible for managing private chats and friends.
 type PrivateChatList struct {

--- a/ui/usertree.go
+++ b/ui/usertree.go
@@ -13,6 +13,8 @@ import (
 	"github.com/gdamore/tcell"
 )
 
+var _ Focusable = (*UserTree)(nil)
+
 // UserTree represents the visual list of users in a guild.
 type UserTree struct {
 	internalTreeView *tview.TreeView

--- a/ui/usertree.go
+++ b/ui/usertree.go
@@ -324,3 +324,10 @@ func (userTree *UserTree) SetInputCapture(capture func(event *tcell.EventKey) *t
 func (userTree *UserTree) IsLoaded() bool {
 	return userTree.loaded
 }
+
+// Focus tells a UI component to change the focus
+// of the given application to itself
+// Implements Focusable
+func (userTree *UserTree) SetFocus(app *tview.Application) {
+	app.SetFocus(userTree.internalTreeView)
+}

--- a/ui/window.go
+++ b/ui/window.go
@@ -208,7 +208,7 @@ func NewWindow(doRestart chan bool, app *tview.Application, session *discordgo.S
 			window.ShowErrorDialog(channelLoadError.Error())
 		} else {
 			if config.Current.FocusChannelAfterGuildSelection {
-				app.SetFocus(window.channelTree)
+				window.channelTree.SetFocus(window.app)
 			}
 		}
 
@@ -331,7 +331,7 @@ func NewWindow(doRestart chan bool, app *tview.Application, session *discordgo.S
 
 		if shortcuts.ReplySelectedMessage.Equals(event) {
 			window.messageInput.SetText("@" + message.Author.Username + "#" + message.Author.Discriminator + " " + window.messageInput.GetText())
-			app.SetFocus(window.messageInput.GetPrimitive())
+			window.messageInput.SetFocus(window.app)
 			return nil
 		}
 
@@ -491,7 +491,7 @@ func NewWindow(doRestart chan bool, app *tview.Application, session *discordgo.S
 		autocompleteView.GetRoot().ClearChildren()
 		if len(values) == 0 {
 			autocompleteView.SetVisible(false)
-			window.app.SetFocus(window.messageInput.GetPrimitive())
+			window.messageInput.SetFocus(window.app)
 		} else {
 			rootNode := autocompleteView.GetRoot()
 			for _, value := range values {
@@ -509,7 +509,7 @@ func NewWindow(doRestart chan bool, app *tview.Application, session *discordgo.S
 	autocompleteView.SetSelectedFunc(func(node *tview.TreeNode) {
 		value := node.GetReference().(*AutocompleteValue)
 		window.messageInput.Autocomplete(value.InsertValue)
-		window.app.SetFocus(window.messageInput.GetPrimitive())
+		window.messageInput.SetFocus(window.app)		
 		autocompleteView.SetVisible(false)
 	})
 
@@ -688,7 +688,6 @@ func NewWindow(doRestart chan bool, app *tview.Application, session *discordgo.S
 
 	captureFunc := func(event *tcell.EventKey) *tcell.EventKey {
 		messageToSend := window.messageInput.GetText()
-
 		if event.Modifiers() == tcell.ModCtrl {
 			if event.Key() == tcell.KeyUp {
 				window.chatView.internalTextView.ScrollUp()
@@ -909,7 +908,6 @@ func NewWindow(doRestart chan bool, app *tview.Application, session *discordgo.S
 					}
 				}
 			}
-		})
 	})
 
 	window.middleContainer = tview.NewFlex().
@@ -1183,7 +1181,7 @@ func (window *Window) loadPrivateChannel(channel *discordgo.Channel) {
 // and then focuses the input primitive.
 func (window *Window) SwitchToPrivateChannel(channel *discordgo.Channel) {
 	window.SwitchToFriendsPage()
-	window.app.SetFocus(window.messageInput.GetPrimitive())
+	window.messageInput.SetFocus(window.app)
 	window.loadPrivateChannel(channel)
 }
 
@@ -1226,7 +1224,7 @@ func (window *Window) insertQuoteOfMessage(message *discordgo.Message) {
 	quotedMessage, generateError := discordutil.GenerateQuote(message.ContentWithMentionsReplaced(), username, message.Timestamp, message.Attachments, window.messageInput.GetText())
 	if generateError == nil {
 		window.messageInput.SetText(quotedMessage)
-		window.app.SetFocus(window.messageInput.GetPrimitive())
+		window.messageInput.SetFocus(window.app)
 	} else {
 		window.ShowErrorDialog(fmt.Sprintf("Error quoting message:\n\t%s", generateError.Error()))
 	}
@@ -1555,7 +1553,7 @@ func (window *Window) ShowDialog(color tcell.Color, text string, buttonHandler f
 func (window *Window) registerMouseFocusListeners() {
 	window.chatView.internalTextView.SetMouseHandler(func(event *tcell.EventMouse) bool {
 		if event.Buttons() == tcell.Button1 {
-			window.app.SetFocus(window.chatView.internalTextView)
+			window.chatView.SetFocus(window.app)
 		} else if event.Buttons() == tcell.WheelDown {
 			window.chatView.internalTextView.ScrollDown()
 		} else if event.Buttons() == tcell.WheelUp {
@@ -1575,11 +1573,11 @@ func (window *Window) registerMouseFocusListeners() {
 				//Avoid triggering multiple times in a row due to mouse movement during the click
 				if nowMillis-lastLeftContainerSwitchTimeMillis > 60 {
 					window.SwitchToGuildsPage()
-					window.app.SetFocus(window.guildList)
+					window.guildList.SetFocus(window.app)
 				}
 				lastLeftContainerSwitchTimeMillis = nowMillis
 			} else {
-				window.app.SetFocus(window.guildList)
+				window.guildList.SetFocus(window.app)
 			}
 			return true
 		}
@@ -1588,7 +1586,7 @@ func (window *Window) registerMouseFocusListeners() {
 	})
 	window.channelTree.SetMouseHandler(func(event *tcell.EventMouse) bool {
 		if event.Buttons() == tcell.Button1 {
-			window.app.SetFocus(window.channelTree)
+			window.channelTree.SetFocus(window.app)
 
 			return true
 		}
@@ -1598,7 +1596,7 @@ func (window *Window) registerMouseFocusListeners() {
 
 	window.userList.internalTreeView.SetMouseHandler(func(event *tcell.EventMouse) bool {
 		if event.Buttons() == tcell.Button1 {
-			window.app.SetFocus(window.userList.internalTreeView)
+			window.userList.SetFocus(window.app)
 
 			return true
 		}
@@ -1613,11 +1611,11 @@ func (window *Window) registerMouseFocusListeners() {
 				//Avoid triggering multiple times in a row due to mouse movement during the click
 				if nowMillis-lastLeftContainerSwitchTimeMillis > 60 {
 					window.SwitchToFriendsPage()
-					window.app.SetFocus(window.privateList.internalTreeView)
+					window.privateList.SetFocus(window.app)
 				}
 				lastLeftContainerSwitchTimeMillis = nowMillis
 			} else {
-				window.app.SetFocus(window.privateList.internalTreeView)
+				window.privateList.SetFocus(window.app)
 			}
 			return true
 		}
@@ -1627,7 +1625,7 @@ func (window *Window) registerMouseFocusListeners() {
 
 	window.messageInput.internalTextView.SetMouseHandler(func(event *tcell.EventMouse) bool {
 		if event.Buttons() == tcell.Button1 {
-			window.app.SetFocus(window.messageInput.internalTextView)
+			window.messageInput.SetFocus(window.app)
 
 			return true
 		}
@@ -1637,7 +1635,7 @@ func (window *Window) registerMouseFocusListeners() {
 
 	window.commandView.commandInput.internalTextView.SetMouseHandler(func(event *tcell.EventMouse) bool {
 		if event.Buttons() == tcell.Button1 {
-			window.app.SetFocus(window.commandView.commandInput.internalTextView)
+			window.commandView.SetFocus(window.app)
 
 			return true
 		}
@@ -1647,7 +1645,7 @@ func (window *Window) registerMouseFocusListeners() {
 
 	window.commandView.commandOutput.SetMouseHandler(func(event *tcell.EventMouse) bool {
 		if event.Buttons() == tcell.Button1 {
-			window.app.SetFocus(window.commandView.commandOutput)
+			window.commandView.SetFocus(window.app)
 		} else if event.Buttons() == tcell.WheelDown {
 			window.commandView.commandOutput.ScrollDown()
 		} else if event.Buttons() == tcell.WheelUp {
@@ -2174,12 +2172,12 @@ func (window *Window) handleGlobalShortcuts(event *tcell.EventKey) *tcell.EventK
 	//This two have to work in baremode as well, since otherwise only the mouse
 	//can be used for focus switching, which sucks in a terminal app.
 	if shortcuts.FocusMessageInput.Equals(event) {
-		window.app.SetFocus(window.messageInput.GetPrimitive())
+		window.messageInput.SetFocus(window.app)
 		return nil
 	}
 
 	if shortcuts.FocusMessageContainer.Equals(event) {
-		window.app.SetFocus(window.chatView.internalTextView)
+		window.chatView.SetFocus(window.app)
 		return nil
 	}
 
@@ -2200,30 +2198,30 @@ func (window *Window) handleGlobalShortcuts(event *tcell.EventKey) *tcell.EventK
 		window.SetCommandModeEnabled(!window.commandMode)
 
 		if window.commandMode {
-			window.app.SetFocus(window.commandView.commandInput.internalTextView)
+			window.commandView.SetFocus(window.app)
 		} else {
-			window.app.SetFocus(window.messageInput.GetPrimitive())
+			window.messageInput.SetFocus(window.app)
 		}
 	} else if shortcuts.FocusCommandOutput.Equals(event) {
 		if !window.commandMode {
 			window.SetCommandModeEnabled(true)
 		}
 
-		window.app.SetFocus(window.commandView.commandOutput)
+		window.commandView.SetFocus(window.app)
 	} else if shortcuts.FocusCommandInput.Equals(event) {
 		if !window.commandMode {
 			window.SetCommandModeEnabled(true)
 		}
 
-		window.app.SetFocus(window.commandView.commandInput.internalTextView)
+		window.commandView.SetFocus(window.app)
 	} else if shortcuts.ToggleUserContainer.Equals(event) {
 		window.toggleUserContainer()
 	} else if shortcuts.FocusChannelContainer.Equals(event) {
 		window.SwitchToGuildsPage()
-		window.app.SetFocus(window.channelTree)
+		window.channelTree.SetFocus(window.app)
 	} else if shortcuts.FocusPrivateChatPage.Equals(event) {
 		window.SwitchToFriendsPage()
-		window.app.SetFocus(window.privateList.GetComponent())
+		window.privateList.SetFocus(window.app)
 	} else if shortcuts.SwitchToPreviousChannel.Equals(event) {
 		err := window.SwitchToPreviousChannel()
 		if err != nil {
@@ -2231,10 +2229,10 @@ func (window *Window) handleGlobalShortcuts(event *tcell.EventKey) *tcell.EventK
 		}
 	} else if shortcuts.FocusGuildContainer.Equals(event) {
 		window.SwitchToGuildsPage()
-		window.app.SetFocus(window.guildList)
+		window.guildList.SetFocus(window.app)
 	} else if shortcuts.FocusUserContainer.Equals(event) {
 		if window.activeView == Guilds && window.userList.internalTreeView.IsVisible() {
-			window.app.SetFocus(window.userList.internalTreeView)
+			window.userList.SetFocus(window.app)
 		}
 	} else {
 		return event
@@ -2247,7 +2245,7 @@ func (window *Window) toggleUserContainer() {
 	config.Current.ShowUserContainer = !config.Current.ShowUserContainer
 
 	if !config.Current.ShowUserContainer && window.app.GetFocus() == window.userList.internalTreeView {
-		window.app.SetFocus(window.messageInput.GetPrimitive())
+		window.messageInput.SetFocus(window.app)
 	}
 
 	if config.Current.ShowUserContainer {
@@ -2280,7 +2278,7 @@ func (window *Window) toggleBareChat() {
 	} else {
 		window.chatView.internalTextView.SetBorderSides(true, true, true, true)
 		window.app.SetRoot(window.rootContainer, true)
-		window.app.SetFocus(window.messageInput.GetPrimitive())
+		window.messageInput.SetFocus(window.app)
 	}
 
 	window.app.QueueUpdateDraw(func() {
@@ -2418,7 +2416,7 @@ func (window *Window) startEditingMessage(message *discordgo.Message) {
 			window.messageInput.SetBorderFocusAttributes(tcell.AttrBlink | tcell.AttrBold)
 		}
 		window.editingMessageID = &message.ID
-		window.app.SetFocus(window.messageInput.GetPrimitive())
+		window.messageInput.SetFocus(window.app)
 	}
 }
 
@@ -2542,7 +2540,7 @@ func (window *Window) SwitchToPreviousChannel() error {
 	default:
 		return fmt.Errorf("Invalid channel type: %v", window.previousChannel.Type)
 	}
-	window.app.SetFocus(window.messageInput.internalTextView)
+	window.messageInput.SetFocus(window.app)
 	return nil
 }
 
@@ -2624,7 +2622,7 @@ func (window *Window) LoadChannel(channel *discordgo.Channel) error {
 	window.exitMessageEditModeAndKeepText()
 
 	if config.Current.FocusMessageInputAfterChannelSelection {
-		window.app.SetFocus(window.messageInput.internalTextView)
+		window.messageInput.SetFocus(window.app)
 	}
 
 	go func() {

--- a/ui/window.go
+++ b/ui/window.go
@@ -65,7 +65,7 @@ type Window struct {
 	privateList *PrivateChatList
 
 	chatArea         *tview.Flex
-	chatView         *ChatView
+	chatView         ChatViewInterface
 	messageContainer tview.Primitive
 	messageInput     *Editor
 
@@ -282,7 +282,6 @@ func NewWindow(doRestart chan bool, app *tview.Application, session *discordgo.S
 					return
 				}
 			}
-
 			newChannel, discordError := window.session.UserChannelCreate(userID)
 			if discordError == nil {
 				messages, discordError := window.session.ChannelMessages(newChannel.ID, 100, "", "", "")


### PR DESCRIPTION
Hi Marcel,

As per discussion on #212, I'm raising the PR for you to take a look at. Unfortunately, I can't raise this against a new branch on your repo :( so I know you won't merge this PR as it stands. If you create a new branch, I'll happily update my PR to point at it; or you can update it, I'm not fussed.

The PR introduces some refactoring to introduce a new `ui.ChatViewInterface `interface on which both `ui.Window` and `ui.ChatView` can rely. That should make it easier to introduce a new implementation of the chat view in the future. It makes a not-insignificant amount of small changes to the `ui.Window` type in order to decouple it from the internals of `ui.ChatView`. 

It also starts to decouple `ui.Window` from other UI components by introducing the `ui.Focusable` interface which describes UI components which can focus themselves. I've done this because `ui.Window` was coupling itself to the internals of other components, by directly referencing their internal implementations. The replacement method is implemented like a [visitor] (https://en.wikipedia.org/wiki/Visitor_pattern), and allows the UI components to decide how they should take focus for themselves.

I hope this is helpful to you, but I also won't be offended if you choose to not to merge it in.

Thanks,
Andy