### PR TITLE
added some limited reply message scripting

### DIFF
--- a/scripting/engine.go
+++ b/scripting/engine.go
@@ -34,4 +34,6 @@ type Engine interface {
 
 	SetGetCurrentGuildFunction(func() string)
 	SetGetCurrentChannelFunction(func() string)
+
+	SetReplyMessageFunction(func(string, string))
 }

--- a/scripting/engine.go
+++ b/scripting/engine.go
@@ -35,5 +35,5 @@ type Engine interface {
 	SetGetCurrentGuildFunction(func() string)
 	SetGetCurrentChannelFunction(func() string)
 
-	SetReplyMessageFunction(func(string, string))
+	SetReplyMessageFunction(func(discordgo.Message, string))
 }

--- a/scripting/js/javascript.go
+++ b/scripting/js/javascript.go
@@ -306,6 +306,25 @@ func (engine *JavaScriptEngine) SetTriggerNotificationFunction(function func(tit
 	engine.setFunctionOnVMs("triggerNotification", triggerNotification)
 }
 
+// SetReplyMessageFunction implements Engine
+func (engine *JavaScriptEngine) SetReplyMessageFunction(function func(channelID string, text string)) {
+	triggerNotification := func(call otto.FunctionCall) otto.Value {
+		channelID, argError := call.Argument(0).ToString()
+		if argError != nil {
+			log.Printf("Error invoking replyMessageFunction in JS engine: %s\n", argError)
+			return nullValue
+		}
+		text, argError := call.Argument(1).ToString()
+		if argError != nil {
+			log.Printf("Error invoking replyMessageFunction in JS engine: %s\n", argError)
+			return nullValue
+		}
+		function(channelID, text)
+		return nullValue
+	}
+	engine.setFunctionOnVMs("replyMessage", triggerNotification)
+}
+
 // SetPrintToConsoleFunction implements Engine
 func (engine *JavaScriptEngine) SetPrintToConsoleFunction(function func(text string)) {
 	printToConsole := func(call otto.FunctionCall) otto.Value {

--- a/ui/window.go
+++ b/ui/window.go
@@ -1104,6 +1104,13 @@ func (window *Window) initExtensionEngine(engine scripting.Engine) error {
 		fmt.Fprintln(window.commandView, text)
 	})
 
+	engine.SetReplyMessageFunction(func(channelID string, text string) {
+		channel, cacheError := window.session.State.Channel(channelID)
+		if cacheError == nil && channel.Type != discordgo.ChannelTypeGuildCategory {
+			window.TrySendMessage(channel, text)
+		}
+	})
+
 	return nil
 }
 

--- a/ui/window.go
+++ b/ui/window.go
@@ -1104,8 +1104,8 @@ func (window *Window) initExtensionEngine(engine scripting.Engine) error {
 		fmt.Fprintln(window.commandView, text)
 	})
 
-	engine.SetReplyMessageFunction(func(channelID string, text string) {
-		channel, cacheError := window.session.State.Channel(channelID)
+	engine.SetReplyMessageFunction(func(message discordgo.Message, text string) {
+		channel, cacheError := window.session.State.Channel(message.ChannelID)
 		if cacheError == nil && channel.Type != discordgo.ChannelTypeGuildCategory {
 			window.TrySendMessage(channel, text)
 		}


### PR DESCRIPTION
This is going to be a controversial PR. Basically, I added a new scripting hook that allows you to call replyMessage(message, text) and it will send a message in the same channel as the one passed in. This restricts automation to only replying to messages (you cannot send a message in an arbitrary channel etc). 

We could also add some strict rate limiting (1 message per minute or something). This feature is NOT intended to allow user bots, but more to allow something like an auto-reply when you are away. Example: "Hey there, I am offline until x on vacation. If it is urgent, please do y".

I think this could be a valuable and useful feature. Please discuss with me what might make this suitable for merging.

(P.S. this is my first time using Go, so if something is a little rough, please go easy haha)